### PR TITLE
Fix MaxSdkCallbacks not loading after first try when Enter Play Mode …

### DIFF
--- a/DemoApp/Assets/MaxSdk/Scripts/MaxSdkUnityEditor.cs
+++ b/DemoApp/Assets/MaxSdk/Scripts/MaxSdkUnityEditor.cs
@@ -36,7 +36,8 @@ public class MaxSdkUnityEditor : MaxSdkBase
         get { return MaxUserServiceUnityEditor.Instance; }
     }
 
-    static MaxSdkUnityEditor()
+    [InitializeOnLoadMethod]
+    private static void MaxSdkEditorInitialization()
     {
         InitCallbacks();
     }


### PR DESCRIPTION
…Settings is activated

Hi, I have encountered a problem where max SDK plugin crashes with enter play mode activated.
This happens because it depends on static constructors, and they only run when the c# context is first built


Steps to reproduce:
1. open a unity project with max SDK plugin integrated
2. enable enter play mode settings
3. play the project
4. stop
5. try to play again

The project will not execute properly because of an exception in max SDK initialization.

This fix will avoid the crash but there are still less critical exceptions that occur for the same reason.